### PR TITLE
Prevent the app Home page from loading docker images twice

### DIFF
--- a/public/src/apps/App.jsx
+++ b/public/src/apps/App.jsx
@@ -201,7 +201,6 @@ export class App extends React.Component {
 
     componentDidMount() {
         this.props.activateTab('home');
-        this.loadData();
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
this.loadData() is already called whenever the props update, which
happens on mount, so the call to this.loadData() in componentDidMount()
is redundant.