### PR TITLE
Add preliminary environment management

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -51,6 +51,10 @@ func AddHandlers(s *server.Server, envs *util.StringSet) {
 	s.Echo().Post("/api/v1/releases/:app/:tag", middleware.RequireUser(releaseCreateHandler))
 	s.Echo().Delete("/api/v1/releases/:app/:tag", middleware.RequireUser(releaseDeleteHandler))
 
+	// environments
+	s.Echo().Put("/api/v1/environments/:env", middleware.RequireUser(environmentCreateHandler))
+	s.Echo().Delete("/api/v1/environments/:env", middleware.RequireUser(environmentDeleteHandler))
+
 	// catchall not found handler
 	s.Echo().Get("/api/*", middleware.RequireUser(notFoundHandler))
 }

--- a/api/api.go
+++ b/api/api.go
@@ -52,7 +52,7 @@ func AddHandlers(s *server.Server) {
 	s.Echo().Delete("/api/v1/releases/:app/:tag", middleware.RequireUser(releaseDeleteHandler))
 
 	// environments
-	s.Echo().Put("/api/v1/environments/:env", middleware.RequireUser(environmentCreateHandler))
+	s.Echo().Post("/api/v1/environments", middleware.RequireUser(environmentCreateHandler))
 	s.Echo().Delete("/api/v1/environments/:env", middleware.RequireUser(environmentDeleteHandler))
 
 	// catchall not found handler

--- a/api/api.go
+++ b/api/api.go
@@ -3,10 +3,10 @@ package api
 import (
 	"sync"
 
+	"github.com/airware/vili/environments"
 	"github.com/airware/vili/errors"
 	"github.com/airware/vili/middleware"
 	"github.com/airware/vili/server"
-	"github.com/airware/vili/util"
 	"github.com/labstack/echo"
 )
 
@@ -17,35 +17,35 @@ var WaitGroup sync.WaitGroup
 var Exiting = false
 
 // AddHandlers adds api handlers to the server
-func AddHandlers(s *server.Server, envs *util.StringSet) {
+func AddHandlers(s *server.Server) {
 	envPrefix := "/api/v1/envs/:env/"
 	// apps
-	s.Echo().Get(envPrefix+"apps", envMiddleware(envs, appsHandler))
-	s.Echo().Get(envPrefix+"apps/:app", envMiddleware(envs, appHandler))
-	s.Echo().Post(envPrefix+"apps/:app/service", envMiddleware(envs, appCreateServiceHandler))
-	s.Echo().Put(envPrefix+"apps/:app/scale", envMiddleware(envs, appScaleHandler))
+	s.Echo().Get(envPrefix+"apps", envMiddleware(appsHandler))
+	s.Echo().Get(envPrefix+"apps/:app", envMiddleware(appHandler))
+	s.Echo().Post(envPrefix+"apps/:app/service", envMiddleware(appCreateServiceHandler))
+	s.Echo().Put(envPrefix+"apps/:app/scale", envMiddleware(appScaleHandler))
 
 	// jobs
-	s.Echo().Get(envPrefix+"jobs/:job", envMiddleware(envs, jobHandler))
+	s.Echo().Get(envPrefix+"jobs/:job", envMiddleware(jobHandler))
 
 	// nodes
-	s.Echo().Get(envPrefix+"nodes", envMiddleware(envs, nodesHandler))
-	s.Echo().Get(envPrefix+"nodes/:node", envMiddleware(envs, nodeHandler))
-	s.Echo().Put(envPrefix+"nodes/:node/:state", envMiddleware(envs, nodeStateEditHandler))
+	s.Echo().Get(envPrefix+"nodes", envMiddleware(nodesHandler))
+	s.Echo().Get(envPrefix+"nodes/:node", envMiddleware(nodeHandler))
+	s.Echo().Put(envPrefix+"nodes/:node/:state", envMiddleware(nodeStateEditHandler))
 
 	// pods
-	s.Echo().Get(envPrefix+"pods", envMiddleware(envs, podsHandler))
-	s.Echo().Get(envPrefix+"pods/:pod", envMiddleware(envs, podHandler))
-	s.Echo().Delete(envPrefix+"pods/:pod", envMiddleware(envs, podDeleteHandler))
+	s.Echo().Get(envPrefix+"pods", envMiddleware(podsHandler))
+	s.Echo().Get(envPrefix+"pods/:pod", envMiddleware(podHandler))
+	s.Echo().Delete(envPrefix+"pods/:pod", envMiddleware(podDeleteHandler))
 
 	// deployments
-	s.Echo().Post(envPrefix+"apps/:app/deployments", envMiddleware(envs, deploymentCreateHandler))
-	s.Echo().Put(envPrefix+"apps/:app/deployments/:deployment/rollout", envMiddleware(envs, deploymentRolloutEditHandler))
-	s.Echo().Post(envPrefix+"apps/:app/deployments/:deployment/:action", envMiddleware(envs, deploymentActionHandler))
+	s.Echo().Post(envPrefix+"apps/:app/deployments", envMiddleware(deploymentCreateHandler))
+	s.Echo().Put(envPrefix+"apps/:app/deployments/:deployment/rollout", envMiddleware(deploymentRolloutEditHandler))
+	s.Echo().Post(envPrefix+"apps/:app/deployments/:deployment/:action", envMiddleware(deploymentActionHandler))
 
 	// runs
-	s.Echo().Post(envPrefix+"jobs/:job/runs", envMiddleware(envs, runCreateHandler))
-	s.Echo().Post(envPrefix+"jobs/:job/runs/:run/:action", envMiddleware(envs, runActionHandler))
+	s.Echo().Post(envPrefix+"jobs/:job/runs", envMiddleware(runCreateHandler))
+	s.Echo().Post(envPrefix+"jobs/:job/runs/:run/:action", envMiddleware(runActionHandler))
 
 	// releases
 	s.Echo().Post("/api/v1/releases/:app/:tag", middleware.RequireUser(releaseCreateHandler))
@@ -59,12 +59,14 @@ func AddHandlers(s *server.Server, envs *util.StringSet) {
 	s.Echo().Get("/api/*", middleware.RequireUser(notFoundHandler))
 }
 
-func envMiddleware(envs *util.StringSet, h echo.HandlerFunc) echo.HandlerFunc {
+func envMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 	return middleware.RequireUser(func(c *echo.Context) error {
-		if !envs.Contains(c.Param("env")) {
-			return notFoundHandler(c)
+		for _, env := range environments.Environments() {
+			if c.Param("env") == env.Name {
+				return h(c)
+			}
 		}
-		return h(c)
+		return notFoundHandler(c)
 	})
 }
 

--- a/api/environments.go
+++ b/api/environments.go
@@ -3,44 +3,24 @@ package api
 import (
 	"net/http"
 
-	"github.com/airware/vili/config"
-	"github.com/airware/vili/kube"
-	"github.com/airware/vili/kube/v1"
-	"github.com/airware/vili/util"
+	"github.com/airware/vili/environments"
 	"github.com/labstack/echo"
 )
 
 func environmentCreateHandler(c *echo.Context) error {
 	env := c.Param("env")
 
-	resp, status, err := kube.Namespaces.Create(&v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
-			Name: env,
-		},
-	})
-	if err != nil {
+	if err := environments.Create(env); err != nil {
 		return err
 	}
-	if status != nil {
-		return c.JSON(http.StatusOK, status)
-	}
-	return c.JSON(http.StatusOK, resp)
+	return c.NoContent(http.StatusCreated)
 }
 
 func environmentDeleteHandler(c *echo.Context) error {
 	env := c.Param("env")
 
-	protectedEnvs := util.NewStringSet(config.GetStringSlice(config.Environments))
-	if protectedEnvs.Contains(env) {
-		return c.JSON(http.StatusBadRequest, env+" is a protected environment")
-	}
-
-	status, err := kube.Namespaces.Delete(env)
-	if err != nil {
+	if err := environments.Delete(env); err != nil {
 		return err
-	}
-	if status != nil {
-		return c.JSON(http.StatusOK, status)
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/api/environments.go
+++ b/api/environments.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/airware/vili/config"
+	"github.com/airware/vili/kube"
+	"github.com/airware/vili/kube/v1"
+	"github.com/airware/vili/util"
+	"github.com/labstack/echo"
+)
+
+func environmentCreateHandler(c *echo.Context) error {
+	env := c.Param("env")
+
+	resp, status, err := kube.Namespaces.Create(&v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: env,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if status != nil {
+		return c.JSON(http.StatusOK, status)
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+func environmentDeleteHandler(c *echo.Context) error {
+	env := c.Param("env")
+
+	protectedEnvs := util.NewStringSet(config.GetStringSlice(config.Environments))
+	if protectedEnvs.Contains(env) {
+		return c.JSON(http.StatusBadRequest, env+" is a protected environment")
+	}
+
+	status, err := kube.Namespaces.Delete(env)
+	if err != nil {
+		return err
+	}
+	if status != nil {
+		return c.JSON(http.StatusOK, status)
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/api/environments.go
+++ b/api/environments.go
@@ -1,16 +1,32 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/airware/vili/environments"
 	"github.com/labstack/echo"
 )
 
-func environmentCreateHandler(c *echo.Context) error {
-	env := c.Param("env")
+// EnvironmentCreateRequest is a request to create a new environment
+type EnvironmentCreateRequest struct {
+	Name   string `json:"name"`
+	Branch string `json:"branch"`
+}
 
-	if err := environments.Create(env); err != nil {
+func environmentCreateHandler(c *echo.Context) error {
+	envCreateRequest := &EnvironmentCreateRequest{}
+	decoder := json.NewDecoder(c.Request().Body)
+	err := decoder.Decode(envCreateRequest)
+	if err != nil {
+		return err
+	}
+
+	if envCreateRequest.Name == "" || envCreateRequest.Branch == "" {
+		return c.JSON(http.StatusBadRequest, "Must provide a non-empty name and branch")
+	}
+
+	if err := environments.Create(envCreateRequest.Name, envCreateRequest.Branch); err != nil {
 		return err
 	}
 	return c.NoContent(http.StatusCreated)

--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
 
 	"github.com/labstack/echo"
@@ -70,6 +71,7 @@ func appHandler(envs *util.StringSet) func(c *echo.Context) error {
 		envs.ForEach(func(e string) {
 			envSlice = append(envSlice, e)
 		})
+		sort.Strings(envSlice)
 
 		envApps := make(map[string][]string)
 		envJobs := make(map[string][]string)

--- a/app/app.go
+++ b/app/app.go
@@ -4,19 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
 	"sync"
 
 	"github.com/labstack/echo"
 
 	"github.com/airware/vili/config"
+	"github.com/airware/vili/environments"
 	"github.com/airware/vili/errors"
 	"github.com/airware/vili/firebase"
 	"github.com/airware/vili/log"
 	"github.com/airware/vili/public"
 	"github.com/airware/vili/session"
 	"github.com/airware/vili/templates"
-	"github.com/airware/vili/util"
 )
 
 const homeTemplate = `
@@ -34,14 +33,12 @@ const homeTemplate = `
 
 // AppConfig is the frontend configuration
 type AppConfig struct {
-	URI          string              `json:"uri"`
-	User         *session.User       `json:"user"`
-	Envs         []string            `json:"envs"`
-	ProdEnvs     []string            `json:"prodEnvs"`
-	ApprovalEnvs []string            `json:"approvalEnvs"`
-	EnvApps      map[string][]string `json:"envApps"`
-	EnvJobs      map[string][]string `json:"envJobs"`
-	Firebase     FirebaseConfig      `json:"firebase"`
+	URI      string                     `json:"uri"`
+	User     *session.User              `json:"user"`
+	Envs     []environments.Environment `json:"envs"`
+	EnvApps  map[string][]string        `json:"envApps"`
+	EnvJobs  map[string][]string        `json:"envJobs"`
+	Firebase FirebaseConfig             `json:"firebase"`
 }
 
 // FirebaseConfig is the Firebase configuration
@@ -50,102 +47,92 @@ type FirebaseConfig struct {
 	Token string `json:"token"`
 }
 
-func homeHandler(envs *util.StringSet) func(c *echo.Context) error {
-	return func(c *echo.Context) error {
-		if c.Get("user") == nil {
-			staticLiveReload := config.GetBool(config.StaticLiveReload)
-			return c.HTML(
-				http.StatusOK,
-				homeTemplate,
-				"null",
-				fmt.Sprintf("/static/app-%s.js", public.GetHash(staticLiveReload)),
-			)
-		}
-		return appHandler(envs)(c)
-	}
-}
-
-func appHandler(envs *util.StringSet) func(c *echo.Context) error {
-	return func(c *echo.Context) error {
-		envSlice := []string{}
-		envs.ForEach(func(e string) {
-			envSlice = append(envSlice, e)
-		})
-		sort.Strings(envSlice)
-
-		envApps := make(map[string][]string)
-		envJobs := make(map[string][]string)
-
-		failed := false
-		var wg sync.WaitGroup
-		var appsMutex sync.Mutex
-		var jobsMutex sync.Mutex
-		funcs := []func(env string){
-			func(env string) {
-				defer wg.Done()
-				deployments, err := templates.Deployments(env)
-				if err != nil {
-					log.Error(err)
-					failed = true
-				}
-				appsMutex.Lock()
-				envApps[env] = deployments
-				appsMutex.Unlock()
-			},
-			func(env string) {
-				defer wg.Done()
-				pods, err := templates.Pods(env)
-				if err != nil {
-					log.Error(err)
-					failed = true
-				}
-				jobsMutex.Lock()
-				envJobs[env] = pods
-				jobsMutex.Unlock()
-			},
-		}
-
-		wg.Add(len(funcs) * len(envSlice))
-		for _, f := range funcs {
-			for _, env := range envSlice {
-				go f(env)
-			}
-		}
-		wg.Wait()
-		if failed {
-			return errors.New("failed github call")
-		}
-
-		user, _ := c.Get("user").(*session.User)
-
-		firebaseToken, err := firebase.NewToken(user)
-		if err != nil {
-			return err
-		}
-
-		appConfig := AppConfig{
-			URI:          config.GetString(config.URI),
-			User:         user,
-			Envs:         envSlice,
-			ProdEnvs:     config.GetStringSlice(config.ProdEnvs),
-			ApprovalEnvs: config.GetStringSlice(config.ApprovalEnvs),
-			EnvApps:      envApps,
-			EnvJobs:      envJobs,
-			Firebase: FirebaseConfig{
-				URL:   config.GetString(config.FirebaseURL),
-				Token: firebaseToken,
-			},
-		}
-		appConfigBytes, err := json.Marshal(appConfig)
-		if err != nil {
-			return err
-		}
+func homeHandler(c *echo.Context) error {
+	if c.Get("user") == nil {
 		staticLiveReload := config.GetBool(config.StaticLiveReload)
 		return c.HTML(
 			http.StatusOK,
 			homeTemplate,
-			string(appConfigBytes),
+			"null",
 			fmt.Sprintf("/static/app-%s.js", public.GetHash(staticLiveReload)),
 		)
 	}
+	return appHandler(c)
+}
+
+func appHandler(c *echo.Context) error {
+	envs := environments.Environments()
+
+	envApps := make(map[string][]string)
+	envJobs := make(map[string][]string)
+
+	failed := false
+	var wg sync.WaitGroup
+	var appsMutex sync.Mutex
+	var jobsMutex sync.Mutex
+	funcs := []func(env string){
+		func(env string) {
+			defer wg.Done()
+			deployments, err := templates.Deployments(env)
+			if err != nil {
+				log.Error(err)
+				failed = true
+			}
+			appsMutex.Lock()
+			envApps[env] = deployments
+			appsMutex.Unlock()
+		},
+		func(env string) {
+			defer wg.Done()
+			pods, err := templates.Pods(env)
+			if err != nil {
+				log.Error(err)
+				failed = true
+			}
+			jobsMutex.Lock()
+			envJobs[env] = pods
+			jobsMutex.Unlock()
+		},
+	}
+
+	wg.Add(len(funcs) * len(envs))
+	for _, f := range funcs {
+		for _, env := range envs {
+			go f(env.Name)
+		}
+	}
+	wg.Wait()
+	if failed {
+		return errors.New("failed github call")
+	}
+
+	user, _ := c.Get("user").(*session.User)
+
+	firebaseToken, err := firebase.NewToken(user)
+	if err != nil {
+		return err
+	}
+
+	appConfig := AppConfig{
+		URI:     config.GetString(config.URI),
+		User:    user,
+		Envs:    envs,
+		EnvApps: envApps,
+		EnvJobs: envJobs,
+		Firebase: FirebaseConfig{
+			URL:   config.GetString(config.FirebaseURL),
+			Token: firebaseToken,
+		},
+	}
+	appConfigBytes, err := json.Marshal(appConfig)
+	if err != nil {
+		return err
+	}
+	staticLiveReload := config.GetBool(config.StaticLiveReload)
+	return c.HTML(
+		http.StatusOK,
+		homeTemplate,
+		string(appConfigBytes),
+		fmt.Sprintf("/static/app-%s.js", public.GetHash(staticLiveReload)),
+	)
 }

--- a/environments/environments.go
+++ b/environments/environments.go
@@ -1,0 +1,142 @@
+package environments
+
+import (
+	"errors"
+	"sort"
+	"sync"
+
+	"github.com/airware/vili/kube"
+	"github.com/airware/vili/kube/v1"
+)
+
+var environments []Environment
+var rwMutex sync.RWMutex
+
+// Environment describes an environment backed by a kubernetes namespace
+type Environment struct {
+	Name      string `json:"name"`
+	Protected bool   `json:"protected"`
+	Prod      bool   `json:"prod"`
+	Approval  bool   `json:"approval"`
+}
+
+// Init initializes the global environments list
+func Init(envs []Environment) {
+	rwMutex.Lock()
+	environments = []Environment{}
+	for _, env := range envs {
+		environments = append(environments, env)
+	}
+	sort.Sort(byName(environments))
+	rwMutex.Unlock()
+}
+
+// Environments returns a snapshot of all of the known environments
+func Environments() (ret []Environment) {
+	rwMutex.RLock()
+	for _, env := range environments {
+		ret = append(ret, env)
+	}
+	rwMutex.RUnlock()
+	return
+}
+
+// Create creates a new environment with `name`
+func Create(name string) error {
+	_, status, err := kube.Namespaces.Create(&v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				"airware.feature-environment": name,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if status != nil {
+		return errors.New(status.Message)
+	}
+
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
+	environments = append(environments, Environment{
+		Name: name,
+	})
+	sort.Sort(byName(environments))
+	return nil
+}
+
+// Delete deletes the environment with `name`
+func Delete(name string) error {
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
+	envIndex := -1
+	for i, env := range environments {
+		if env.Name == name {
+			envIndex = i
+			if env.Protected {
+				return errors.New(name + " is a protected environment")
+			}
+		}
+	}
+	if envIndex < 0 {
+		return errors.New(name + " not found")
+	}
+
+	status, err := kube.Namespaces.Delete(name)
+	if err != nil {
+		return err
+	}
+	if status != nil {
+		return errors.New(status.Message)
+	}
+
+	environments = append(environments[:envIndex], environments[envIndex+1:]...)
+
+	return nil
+}
+
+// RefreshEnvs refreshes the list of environments as detected from the kubernetes cluster
+func RefreshEnvs() error {
+	namespaceList, _, err := kube.Namespaces.List(nil)
+	if err != nil {
+		return err
+	}
+
+	newEnvs := []Environment{}
+	rwMutex.Lock()
+	defer rwMutex.Unlock()
+	for _, env := range environments {
+		if env.Protected {
+			newEnvs = append(newEnvs, env)
+		}
+	}
+	for _, namespace := range namespaceList.Items {
+		if namespace.Name != "kube-system" && namespace.Name != "default" {
+			newEnvs = append(newEnvs, Environment{
+				Name: namespace.Name,
+			})
+		}
+	}
+	sort.Sort(byName(newEnvs))
+	environments = newEnvs
+	return nil
+}
+
+type byName []Environment
+
+// Len implements the sort interface
+func (e byName) Len() int {
+	return len(e)
+}
+
+// Less implements the sort interface
+func (e byName) Less(i, j int) bool {
+	return e[i].Name < e[j].Name
+}
+
+// Swap implements the sort interface
+func (e byName) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}

--- a/kube/deployments.go
+++ b/kube/deployments.go
@@ -141,15 +141,14 @@ func (s *DeploymentsService) Rollback(env, name string, data *v1beta1.Deployment
 }
 
 // Delete deletes the deployment in `env` with `name`
-func (s *DeploymentsService) Delete(env, name string) (*v1beta1.Deployment, *unversioned.Status, error) {
+func (s *DeploymentsService) Delete(env, name string) (*unversioned.Status, error) {
 	client, err := getClient(env)
 	if err != nil {
-		return nil, nil, invalidEnvError(env)
+		return nil, invalidEnvError(env)
 	}
-	resp := &v1beta1.Deployment{}
-	status, err := client.makeRequest("DELETE", "deployments/"+name, nil, resp)
+	status, err := client.makeRequest("DELETE", "deployments/"+name, nil, nil)
 	if status != nil || err != nil {
-		return nil, status, err
+		return status, err
 	}
-	return resp, nil, nil
+	return nil, nil
 }

--- a/kube/kube.go
+++ b/kube/kube.go
@@ -35,21 +35,6 @@ type EnvConfig struct {
 	client *client
 }
 
-// DetectEnvs returns the list of environments in the kubernetes cluster
-func DetectEnvs() ([]string, error) {
-	namespaceList, _, err := Namespaces.List(nil)
-	if err != nil {
-		return nil, err
-	}
-	envs := []string{}
-	for _, namespace := range namespaceList.Items {
-		if namespace.Name != "kube-system" {
-			envs = append(envs, namespace.Name)
-		}
-	}
-	return envs, nil
-}
-
 func getClient(env string) (*client, error) {
 	envConfig, ok := kubeconfig.EnvConfigs[env]
 	if ok {

--- a/kube/kube.go
+++ b/kube/kube.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/airware/vili/config"
 	"github.com/airware/vili/kube/unversioned"
-	"github.com/airware/vili/kube/v1"
 )
 
 var kubeconfig *Config
@@ -38,16 +37,10 @@ type EnvConfig struct {
 
 // DetectEnvs returns the list of environments in the kubernetes cluster
 func DetectEnvs() ([]string, error) {
-	client, err := getDefaultClient()
+	namespaceList, _, err := Namespaces.List(nil)
 	if err != nil {
 		return nil, err
 	}
-	namespaceList := &v1.NamespaceList{}
-	_, err = client.makeRequest("GET", "namespaces", nil, namespaceList)
-	if err != nil {
-		return nil, err
-	}
-
 	envs := []string{}
 	for _, namespace := range namespaceList.Items {
 		if namespace.Name != "kube-system" {
@@ -210,6 +203,9 @@ func (c *client) makeRequest(method, path string, body io.Reader, dest interface
 	respBody, status, err := c.makeRequestRaw(method, path, body)
 	if status != nil || err != nil {
 		return status, err
+	}
+	if dest == nil {
+		return nil, nil
 	}
 	return nil, json.Unmarshal(respBody, dest)
 }

--- a/kube/namespaces.go
+++ b/kube/namespaces.go
@@ -1,0 +1,85 @@
+package kube
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+
+	"github.com/airware/vili/kube/unversioned"
+	"github.com/airware/vili/kube/v1"
+)
+
+// Namespaces is the default namespaces service instance
+var Namespaces = &NamespacesService{}
+
+// NamespacesService is the kubernetes service to interace with namespaces
+type NamespacesService struct {
+}
+
+// List fetches the list of namespaces
+func (s *NamespacesService) List(query *url.Values) (*v1.NamespaceList, *unversioned.Status, error) {
+	client, err := getDefaultClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	resp := &v1.NamespaceList{}
+	path := "namespaces"
+	if query != nil {
+		path += "?" + query.Encode()
+	}
+	status, err := client.makeRequest("GET", path, nil, resp)
+	if status != nil || err != nil {
+		return nil, status, err
+	}
+	return resp, nil, nil
+}
+
+// Get fetches the namespace with `name`
+func (s *NamespacesService) Get(name string) (*v1.Namespace, *unversioned.Status, error) {
+	client, err := getDefaultClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	resp := &v1.Namespace{}
+	status, err := client.makeRequest("GET", "namespaces/"+name, nil, resp)
+	if status != nil || err != nil {
+		return nil, status, err
+	}
+	return resp, nil, nil
+}
+
+// Create creates a namespace
+func (s *NamespacesService) Create(data *v1.Namespace) (*v1.Namespace, *unversioned.Status, error) {
+	client, err := getDefaultClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp := &v1.Namespace{}
+	status, err := client.makeRequest(
+		"POST",
+		"namespaces",
+		bytes.NewReader(dataBytes),
+		resp,
+	)
+	if status != nil || err != nil {
+		return nil, status, err
+	}
+	return resp, nil, nil
+}
+
+// Delete deletes the namespace with `name`
+func (s *NamespacesService) Delete(name string) (*unversioned.Status, error) {
+	client, err := getDefaultClient()
+	if err != nil {
+		return nil, err
+	}
+	status, err := client.makeRequest("DELETE", "namespaces/"+name, nil, nil)
+	if status != nil || err != nil {
+		return status, err
+	}
+	return nil, nil
+}

--- a/public/src/apps/AppsList.jsx
+++ b/public/src/apps/AppsList.jsx
@@ -19,7 +19,7 @@ class Row extends React.Component { // eslint-disable-line no-unused-vars
 
     render() {
         var actions = [];
-        if (this.props.envCanApproveTag) {
+        if (this.props.env.approval) {
             if (this.state.approval) {
                 actions.push(<button type="button" className="btn btn-xs btn-danger" onClick={this.unapproveTag}>Unapprove</button>);
 
@@ -30,12 +30,12 @@ class Row extends React.Component { // eslint-disable-line no-unused-vars
 
         var cells = _.union([
             <td data-column="name">
-                <Link to={`/${this.props.env}/apps/${this.props.name}`}>{this.props.name}</Link>
+                <Link to={`/${this.props.env.name}/apps/${this.props.name}`}>{this.props.name}</Link>
             </td>,
             <td data-column="tag">{this.state.tag}</td>,
             <td data-column="replicas">{this.state.replicas}</td>,
             <td data-column="deployed_at">{this.state.deployed_at}</td>,
-        ], this.props.envCanApproveTag ? [
+        ], this.props.env.approval ? [
             <td data-column="approved">{this.state.approvalContents}</td>,
             <td data-column="actions">{actions}</td>,
         ] : []);
@@ -53,7 +53,7 @@ class Row extends React.Component { // eslint-disable-line no-unused-vars
             // TODO count running/ready pods
             this.setState(this.state);
         }
-        if (this.props.envCanApproveTag && this.state.tag) {
+        if (this.props.env.approval && this.state.tag) {
             var db = this.props.db.child('releases').child(this.props.name).child(this.state.tag);
             db.off();
             db.on('value', function(snapshot) {
@@ -139,7 +139,7 @@ export class AppsList extends React.Component {
             {title: 'Tag', key: 'tag'},
             {title: 'Replicas', key: 'replicas'},
             {title: 'Deployed', key: 'deployed_at'},
-        ], this.state.envCanApproveTag ? [
+        ], this.state.env.approval ? [
             {title: 'Approved', key: 'approved'},
             {title: 'Actions', key: 'actions'},
         ] : []);
@@ -149,15 +149,14 @@ export class AppsList extends React.Component {
                 return {
                     _row: <Row name={appName}
                                deployment={self.state.deploymentMap[appName]}
-                               env={self.props.params.env}
+                               env={self.state.env}
                                db={self.props.db}
-                               envCanApproveTag={self.state.envCanApproveTag}
                                ref={'row-' + appName}
                           />,
                 };
             });
 
-        if (self.state.envCanApproveTag) {
+        if (self.state.env.approval) {
             header.push(<ButtonToolbar pullRight={true}>
                 <Button onClick={this.approveAllTags} bsStyle="success" bsSize="small">Approve All</Button>
                 <Button onClick={this.unapproveAllTags} bsStyle="danger" bsSize="small">Unapprove All</Button>
@@ -181,7 +180,7 @@ export class AppsList extends React.Component {
             _.each(state.apps.deployments.items, function(rc) {
                 state.deploymentMap[rc.metadata.name] = rc;
             });
-            state.envCanApproveTag = _.contains(window.appconfig.approvalEnvs, self.props.params.env);
+            state.env = _.findWhere(window.appconfig.envs, {name: self.props.params.env});
             self.setState(state);
         });
     }

--- a/public/src/less/styles.less
+++ b/public/src/less/styles.less
@@ -93,6 +93,13 @@ nav.navbar {
     }
 }
 
+.remove-item {
+   color: '#000000';
+   top: 6px;
+   right: 15px;
+   position: absolute;
+}
+
 .view-header {
     position: relative;
     padding-top: 15px;

--- a/public/src/lib/viliapi.js
+++ b/public/src/lib/viliapi.js
@@ -155,8 +155,8 @@ class ViliApi {
         };
 
         this.environments = {
-            create: function(name) {
-                return makePutRequest('/environments/' + name);
+            create: function(spec) {
+                return makePostRequest('/environments', spec);
             },
             delete: function(name) {
                 return makeDeleteRequest('/environments/' + name);

--- a/public/src/lib/viliapi.js
+++ b/public/src/lib/viliapi.js
@@ -154,6 +154,15 @@ class ViliApi {
             },
         };
 
+        this.environments = {
+            create: function(name) {
+                return makePutRequest('/environments/' + name);
+            },
+            delete: function(name) {
+                return makeDeleteRequest('/environments/' + name);
+            },
+        };
+
     }
 }
 

--- a/public/src/nav/SideNav.jsx
+++ b/public/src/nav/SideNav.jsx
@@ -24,27 +24,27 @@ export class SideNav extends React.Component {
         var nav = [];
         if (this.props.env) {
             var activeItem = this.state.activeItem;
-            var apps = window.appconfig.envApps[this.props.env];
+            var apps = window.appconfig.envApps[this.props.env.name];
             if (!_.isEmpty(apps)) {
-                nav.push(<LinkMenuItem key="apps" to={`/${self.props.env}/apps`}
+                nav.push(<LinkMenuItem key="apps" to={`/${self.props.env.name}/apps`}
                                        active={activeItem[0]==='apps' && !activeItem[1]}>Apps</LinkMenuItem>);
                 _.map(apps, function(app) {
-                    nav.push(<LinkMenuItem key={`apps-${app}`} to={`/${self.props.env}/apps/${app}`} subitem={true}
+                    nav.push(<LinkMenuItem key={`apps-${app}`} to={`/${self.props.env.name}/apps/${app}`} subitem={true}
                                            active={activeItem[0]==='apps' && activeItem[1]===app}>{app}</LinkMenuItem>);
                 });
             }
-            var jobs = window.appconfig.envJobs[this.props.env];
+            var jobs = window.appconfig.envJobs[this.props.env.name];
             if (!_.isEmpty(jobs)) {
-                nav.push(<LinkMenuItem key="jobs" to={`/${self.props.env}/jobs`}
+                nav.push(<LinkMenuItem key="jobs" to={`/${self.props.env.name}/jobs`}
                                        active={activeItem[0]==='jobs' && !activeItem[1]}>Jobs</LinkMenuItem>);
                 _.map(jobs, function(job) {
-                    nav.push(<LinkMenuItem key={`jobs-${job}`} to={`/${self.props.env}/jobs/${job}`} subitem={true}
+                    nav.push(<LinkMenuItem key={`jobs-${job}`} to={`/${self.props.env.name}/jobs/${job}`} subitem={true}
                                            active={activeItem[0]==='jobs' && activeItem[1]===job}>{job}</LinkMenuItem>);
                 });
             }
-            nav.push(<LinkMenuItem key="nodes" to={`/${self.props.env}/nodes`}
+            nav.push(<LinkMenuItem key="nodes" to={`/${self.props.env.name}/nodes`}
                                    active={activeItem[0]==='nodes'}>Nodes</LinkMenuItem>);
-            nav.push(<LinkMenuItem key="pods" to={`/${self.props.env}/pods`}
+            nav.push(<LinkMenuItem key="pods" to={`/${self.props.env.name}/pods`}
                                    active={activeItem[0]==='pods'}>Pods</LinkMenuItem>);
         }
         return (

--- a/public/src/nav/TopNav.jsx
+++ b/public/src/nav/TopNav.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import _ from 'underscore';
 import { Link } from 'react-router'; // eslint-disable-line no-unused-vars
 import { Navbar, Nav, NavDropdown, MenuItem } from 'react-bootstrap'; // eslint-disable-line no-unused-vars
+import { viliApi } from '../lib';
 import { LinkMenuItem } from '../shared'; // eslint-disable-line no-unused-vars
 
 export class TopNav extends React.Component {
@@ -20,7 +21,7 @@ export class TopNav extends React.Component {
                 spath = path.split('/');
             var envElements = window.appconfig.envs.map(function(env) {
                 spath[1] = env;
-                return <LinkMenuItem key={env} to={spath.join('/')} active={env===self.props.env}>{env}</LinkMenuItem>;
+                return <LinkMenuItem key={env} to={spath.join('/')} active={env===self.props.env} onRemove={env===self.props.env ? null : self.deleteEnvironment(env)}>{env}</LinkMenuItem>;
             });
             return (
                 <Navbar className={isProd ? 'prod' : ''}
@@ -37,6 +38,8 @@ export class TopNav extends React.Component {
                         <NavDropdown id="env-dropdown"
                                      title={this.props.env || <span className="text-danger">Select Environment</span>}>
                             {envElements}
+                            <MenuItem divider />
+                            <MenuItem onSelect={this.createNewEnvironment}>Create Environment</MenuItem>
                         </NavDropdown>
                     </Nav>
                 </Navbar>
@@ -54,4 +57,23 @@ export class TopNav extends React.Component {
             );
         }
     }
+
+    createNewEnvironment() {
+        var envName = prompt('Enter the name of the new environment to create');
+        if (!envName) {
+            return;
+        }
+        viliApi.environments.create(envName);
+    }
+
+    deleteEnvironment(env) {
+        return function() {
+            var envName = prompt('Are you sure you wish to delete this environment? Enter the environment name to confirm');
+            if (envName != env) {
+                return
+            }
+            viliApi.environments.delete(envName);
+        }
+    }
+
 }

--- a/public/src/nav/TopNav.jsx
+++ b/public/src/nav/TopNav.jsx
@@ -1,11 +1,25 @@
 import React from 'react';
 import _ from 'underscore';
 import { Link } from 'react-router'; // eslint-disable-line no-unused-vars
-import { Navbar, Nav, NavDropdown, MenuItem } from 'react-bootstrap'; // eslint-disable-line no-unused-vars
+import { Navbar, Nav, NavDropdown, MenuItem, Modal, Label, Input, Button } from 'react-bootstrap'; // eslint-disable-line no-unused-vars
 import { viliApi } from '../lib';
 import { LinkMenuItem } from '../shared'; // eslint-disable-line no-unused-vars
 
 export class TopNav extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showCreateEnvModal: false,
+        }
+
+        this.showCreateEnvModal = this.showCreateEnvModal.bind(this);
+        this.hideCreateEnvModal = this.hideCreateEnvModal.bind(this);
+        this.onEnvNameChange = this.onEnvNameChange.bind(this);
+        this.onEnvBranchChange = this.onEnvBranchChange.bind(this);
+        this.createNewEnvironment = this.createNewEnvironment.bind(this);
+    }
+
     render() {
         var self = this;
 
@@ -49,9 +63,34 @@ export class TopNav extends React.Component {
                                      title={(this.props.env && this.props.env.name) || <span className="text-danger">Select Environment</span>}>
                             {envElements}
                             <MenuItem divider />
-                            <MenuItem onSelect={this.createNewEnvironment}>Create Environment</MenuItem>
+                            <MenuItem onSelect={this.showCreateEnvModal}>Create Environment</MenuItem>
                         </NavDropdown>
                     </Nav>
+                    <Modal show={this.state.showCreateEnvModal} onHide={this.hideCreateEnvModal}>
+                        <Modal.Header closeButton>
+                            <Modal.Title>Create New Environment</Modal.Title>
+                        </Modal.Header>
+                        <Modal.Body>
+                            <Label>Environment Name</Label>
+                            <Input
+                                type="text"
+                                value={this.state.envName}
+                                placeholder="my-feature-environment"
+                                onChange={this.onEnvNameChange}
+                            />
+                            <Label>Default Branch</Label>
+                            <Input
+                                type="text"
+                                value={this.state.envBranch}
+                                placeholder="feature/branch"
+                                onChange={this.onEnvBranchChange}
+                            />
+                        </Modal.Body>
+                        <Modal.Footer>
+                            <Button onClick={this.hideCreateEnvModal}>Close</Button>
+                            <Button bsStyle="primary" onClick={this.createNewEnvironment} disabled={!this.state.envName || !this.state.envBranch}>Create</Button>
+                        </Modal.Footer>
+                    </Modal>
                 </Navbar>
             );
         } else {
@@ -68,12 +107,31 @@ export class TopNav extends React.Component {
         }
     }
 
+    showCreateEnvModal() {
+        this.setState({showCreateEnvModal: true});
+    }
+
+    hideCreateEnvModal() {
+        this.setState({
+            showCreateEnvModal: false,
+            envName: null,
+            envBranch: null,
+        });
+    }
+
+    onEnvNameChange(event) {
+        this.setState({envName: event.target.value});
+    }
+
+    onEnvBranchChange(event) {
+        this.setState({envBranch: event.target.value});
+    }
+
     createNewEnvironment() {
-        var envName = prompt('Enter the name of the new environment to create');
-        if (!envName) {
-            return;
-        }
-        viliApi.environments.create(envName);
+        viliApi.environments.create({
+            name: this.state.envName,
+            branch: this.state.envBranch,
+        });
         window.location.reload();
     }
 

--- a/public/src/router.jsx
+++ b/public/src/router.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Router, { Route, Link, RouteHandler, DefaultRoute } from 'react-router'; // eslint-disable-line no-unused-vars
-
+import _ from 'underscore';
 import { TopNav, SideNav } from './nav' // eslint-disable-line no-unused-vars
 import { AppsList, AppBase, App, AppSpec, AppPods, AppService, AppDeployments, AppDeployment } from './apps' // eslint-disable-line no-unused-vars
 import { JobsList, JobBase, Job, JobSpec, JobRuns, JobRun } from './jobs' // eslint-disable-line no-unused-vars
@@ -23,7 +23,7 @@ class Home extends React.Component {
         var content = '';
         if (window.appconfig) {
             var links = window.appconfig.envs.map(function(env) {
-                return <li><Link key={env} to={`/${env}`}>{env}</Link></li>;
+                return <li><Link key={env.name} to={`/${env.name}`}>{env.name}</Link></li>;
             });
             content = (
                 <div>
@@ -69,12 +69,13 @@ class Environment extends React.Component {
     }
 
     render() {
+        var env = _.findWhere(window.appconfig.envs, {name: this.props.params.env});
         return (
             <div>
-                <TopNav env={this.props.params.env} />
+                <TopNav env={env} />
                 <div className="page-wrapper">
                     <div className="sidebar">
-                        <SideNav env={this.props.params.env} ref="sidenav"/>
+                        <SideNav env={env} ref="sidenav"/>
                     </div>
                     <div className="content-wrapper">
                         <RouteHandler db={this.props.db} activateSideNavItem={this.activateSideNavItem} />

--- a/public/src/shared/LinkMenuItem.jsx
+++ b/public/src/shared/LinkMenuItem.jsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { Link } from 'react-router'; // eslint-disable-line no-unused-vars
 
 export class LinkMenuItem extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.onRemove = this.onRemove.bind(this);
+    }
+
     render() {
         var className='';
         if (this.props.active) {
@@ -10,10 +16,23 @@ export class LinkMenuItem extends React.Component {
         if (this.props.subitem) {
             className += ' subitem';
         }
+        var removeButton = null;
+        if (this.props.onRemove) {
+            removeButton = <span className="glyphicon glyphicon-remove remove-item" onClick={this.onRemove} />;
+        }
         return (
             <li className={className} role="presentation">
-                <Link to={this.props.to}>{this.props.children}</Link>
+                <Link to={this.props.to} style={{ position: 'relative' }}>
+                    {this.props.children}
+                    {removeButton}
+                </Link>
             </li>
         );
+    }
+
+    onRemove(event) {
+        this.props.onRemove(event);
+        event.preventDefault();
+        event.stopPropagation();
     }
 }


### PR DESCRIPTION
Add a Create Environment prompt in the environments dropdown.
Add an "X" delete icon to each environment in the same dropdown.
Disallow deleting explicitly-defined ("protected") environments in the API.

TODO:
- [x] Don't display the "remove environment" button for explicitly-defined environments
- [x] Modals instead of prompts for create/remove environment