### PR TITLE
Allow creating an environment from a spec template

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,6 +1,6 @@
-FROM alpine:3.2
+FROM alpine:3.4
 
-RUN apk add --update ca-certificates
+RUN apk add --update curl ca-certificates
 RUN apk add xmlsec --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/
 RUN ln -s libxmlsec1-openssl.so.1 /usr/lib/libxmlsec1-openssl.so
 
@@ -11,8 +11,12 @@ ENV BUILD_DIR=/app/build
 ENV NODE_ENV=production
 
 RUN mkdir /app
-ADD main /app/
-ADD build /app/build/
+COPY main /app/
+COPY build /app/build/
+
+# Install kubectl
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v1.2.6/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+ && chmod +x /usr/local/bin/kubectl
 
 EXPOSE 80
 ENTRYPOINT ["/app/main"]

--- a/api/api.go
+++ b/api/api.go
@@ -52,6 +52,7 @@ func AddHandlers(s *server.Server) {
 	s.Echo().Delete("/api/v1/releases/:app/:tag", middleware.RequireUser(releaseDeleteHandler))
 
 	// environments
+	s.Echo().Get("/api/v1/envtemplates", middleware.RequireUser(environmentTemplateHandler))
 	s.Echo().Post("/api/v1/environments", middleware.RequireUser(environmentCreateHandler))
 	s.Echo().Delete("/api/v1/environments/:env", middleware.RequireUser(environmentDeleteHandler))
 

--- a/public/src/envs/EnvCreateModal.jsx
+++ b/public/src/envs/EnvCreateModal.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import * as _ from 'underscore';
+import { Promise } from 'bluebird';
+import { viliApi, template } from '../lib';
+import { Modal, Label, Input, Button, ListGroup, ListGroupItem, Panel } from 'react-bootstrap'; // eslint-disable-line no-unused-vars
+
+
+export class EnvCreateModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            show: true,
+        };
+
+        this.hide = this.hide.bind(this);
+        this.onNameChange = this.onNameChange.bind(this);
+        this.onBranchChange = this.onBranchChange.bind(this);
+        this.loadTemplate = _.debounce(this.loadTemplate.bind(this), 200);
+        this.onSpecChange = this.onSpecChange.bind(this);
+        this.createNewEnvironment = this.createNewEnvironment.bind(this);
+    }
+
+    render() {
+        var self = this;
+        var createButton = (
+            <Button
+                bsStyle="primary"
+                onClick={this.createNewEnvironment}
+                disabled={!this.state.spec || this.state.error}>
+                Create
+            </Button>
+        );
+        var specForm = null;
+        if (this.state.name && this.state.branch) {
+            specForm =
+                [
+                    <Label>Environment Spec</Label>,
+                    <Input
+                        type="textarea"
+                        value={this.state.spec}
+                        onChange={this.onSpecChange}
+                        style={{'height': '400px'}}
+                        disabled={this.state.createdResources}
+                    />,
+                ];
+        }
+        var output = null;
+        if (this.state.createdResources) {
+            var createdResources = _.clone(this.state.createdResources);
+            var namespaces = _.map(createdResources.namespace, function(name) {
+                var style = 'success';
+                if (name != self.state.name) {
+                    style = 'danger';
+                }
+                return <ListGroupItem bsStyle={style}>Created namespace {name}</ListGroupItem>;
+            })
+            delete(createdResources.namespace)
+            var resources = _.mapObject(createdResources, function(names, type) {
+                return _.map(names, function(name) {
+                    return <ListGroupItem bsStyle="success">Created {type} {name}</ListGroupItem>;
+                });
+            });
+            output = (
+                <ListGroup>
+                    {namespaces}
+                    {resources}
+                </ListGroup>
+            );
+            createButton = null;
+        } else if (this.state.error) {
+            var errorMessage = _.map(this.state.error.response.body.split("\n"), function(text) {
+                return <div>{text}</div>;
+            })
+            output = <Panel header='Error' bsStyle='danger'>{errorMessage}</Panel>;
+        }
+        return (
+            <Modal show="true" onHide={this.hide}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Create New Environment</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <Label>Environment Name</Label>
+                    <Input
+                        type="text"
+                        value={this.state.name}
+                        placeholder="my-feature-environment"
+                        onChange={this.onNameChange}
+                        disabled={this.state.createdResources}
+                    />
+                    <Label>Default Branch</Label>
+                    <Input
+                        type="text"
+                        value={this.state.branch}
+                        placeholder="feature/branch"
+                        onChange={this.onBranchChange}
+                        disabled={this.state.createdResources}
+                    />
+                    {specForm}
+                    {output}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button onClick={this.hide}>Close</Button>
+                    {createButton}
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+
+    hide() {
+        this.setState({
+            name: null,
+            branch: null,
+            template: null,
+        });
+        if (this.props.onHide) {
+            this.props.onHide();
+        }
+        if (this.state.createdResources) {
+            window.location.reload();
+        }
+    }
+
+    onNameChange(event) {
+        var name = event.target.value;
+        this.setState({
+            name: name,
+            createdResources: null,
+            error: null,
+        });
+        this.loadTemplate(name, this.state.branch);
+    }
+
+    onBranchChange(event) {
+        var branch = event.target.value;
+        this.setState({
+            branch: branch,
+            createdResources: null,
+            error: null,
+        });
+        this.loadTemplate(this.state.name, branch);
+    }
+
+    loadTemplate(name, branch) {
+        if (!name || !branch) {
+            return;
+        }
+        var self = this;
+        viliApi.environments.template(branch).then(function(resp) {
+            var templ = template(resp.template, {
+                NAMESPACE: name,
+                BRANCH: branch,
+            });
+            self.setState({spec: templ.populated});
+        });
+    }
+
+    onSpecChange(event) {
+        this.setState({
+            spec: event.target.value,
+            createdResources: null,
+            error: null,
+        });
+    }
+
+    createNewEnvironment() {
+        var self = this;
+        viliApi.environments.create({
+            name: this.state.name,
+            branch: this.state.branch,
+            spec: this.state.spec,
+        }).then(function(resp) {
+            self.setState({createdResources: resp})
+        }, function(error) {
+            self.setState({error: error})
+        });
+    }
+}

--- a/public/src/envs/index.js
+++ b/public/src/envs/index.js
@@ -1,0 +1,3 @@
+import { EnvCreateModal } from './EnvCreateModal';
+
+export { EnvCreateModal };

--- a/public/src/lib/viliapi.js
+++ b/public/src/lib/viliapi.js
@@ -161,6 +161,9 @@ class ViliApi {
             delete: function(name) {
                 return makeDeleteRequest('/environments/' + name);
             },
+            template: function(branch) {
+                return makeGetRequest('/envtemplates?branch=' + branch);
+            }
         };
 
     }

--- a/public/src/nav/TopNav.jsx
+++ b/public/src/nav/TopNav.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import _ from 'underscore';
 import { Link } from 'react-router'; // eslint-disable-line no-unused-vars
-import { Navbar, Nav, NavDropdown, MenuItem, Modal, Label, Input, Button } from 'react-bootstrap'; // eslint-disable-line no-unused-vars
+import { Navbar, Nav, NavDropdown, MenuItem } from 'react-bootstrap'; // eslint-disable-line no-unused-vars
 import { viliApi } from '../lib';
 import { LinkMenuItem } from '../shared'; // eslint-disable-line no-unused-vars
+import { EnvCreateModal } from '../envs';
 
 export class TopNav extends React.Component {
     constructor(props) {
@@ -15,9 +15,6 @@ export class TopNav extends React.Component {
 
         this.showCreateEnvModal = this.showCreateEnvModal.bind(this);
         this.hideCreateEnvModal = this.hideCreateEnvModal.bind(this);
-        this.onEnvNameChange = this.onEnvNameChange.bind(this);
-        this.onEnvBranchChange = this.onEnvBranchChange.bind(this);
-        this.createNewEnvironment = this.createNewEnvironment.bind(this);
     }
 
     render() {
@@ -47,6 +44,10 @@ export class TopNav extends React.Component {
                     {env.name}
                 </LinkMenuItem>;
             });
+            var envCreateModal = null;
+            if (this.state.showCreateEnvModal) {
+                envCreateModal = <EnvCreateModal onHide={this.hideCreateEnvModal} />;
+            }
             return (
                 <Navbar className={this.props.env && this.props.env.prod ? 'prod' : ''}
                         fixedTop={true} fluid={true}>
@@ -66,31 +67,7 @@ export class TopNav extends React.Component {
                             <MenuItem onSelect={this.showCreateEnvModal}>Create Environment</MenuItem>
                         </NavDropdown>
                     </Nav>
-                    <Modal show={this.state.showCreateEnvModal} onHide={this.hideCreateEnvModal}>
-                        <Modal.Header closeButton>
-                            <Modal.Title>Create New Environment</Modal.Title>
-                        </Modal.Header>
-                        <Modal.Body>
-                            <Label>Environment Name</Label>
-                            <Input
-                                type="text"
-                                value={this.state.envName}
-                                placeholder="my-feature-environment"
-                                onChange={this.onEnvNameChange}
-                            />
-                            <Label>Default Branch</Label>
-                            <Input
-                                type="text"
-                                value={this.state.envBranch}
-                                placeholder="feature/branch"
-                                onChange={this.onEnvBranchChange}
-                            />
-                        </Modal.Body>
-                        <Modal.Footer>
-                            <Button onClick={this.hideCreateEnvModal}>Close</Button>
-                            <Button bsStyle="primary" onClick={this.createNewEnvironment} disabled={!this.state.envName || !this.state.envBranch}>Create</Button>
-                        </Modal.Footer>
-                    </Modal>
+                    {envCreateModal}
                 </Navbar>
             );
         } else {
@@ -108,31 +85,15 @@ export class TopNav extends React.Component {
     }
 
     showCreateEnvModal() {
-        this.setState({showCreateEnvModal: true});
+        this.setState({
+            showCreateEnvModal: true,
+        });
     }
 
     hideCreateEnvModal() {
         this.setState({
             showCreateEnvModal: false,
-            envName: null,
-            envBranch: null,
         });
-    }
-
-    onEnvNameChange(event) {
-        this.setState({envName: event.target.value});
-    }
-
-    onEnvBranchChange(event) {
-        this.setState({envBranch: event.target.value});
-    }
-
-    createNewEnvironment() {
-        viliApi.environments.create({
-            name: this.state.envName,
-            branch: this.state.envBranch,
-        });
-        window.location.reload();
     }
 
     deleteEnvironment(env) {

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -16,6 +16,7 @@ type Service interface {
 	Deployment(env, name string) (Template, error)
 	Pods(env string) ([]string, error)
 	Pod(env, name string) (Template, error)
+	Environment(branch string) (Template, error)
 	Variables(env string) (map[string]string, error)
 }
 
@@ -37,6 +38,11 @@ func Pods(env string) ([]string, error) {
 // Pod returns a list of pods for the given environment
 func Pod(env, name string) (Template, error) {
 	return service.Pod(env, name)
+}
+
+// Environment returns an environment template for the given branch
+func Environment(branch string) (Template, error) {
+	return service.Environment(branch)
 }
 
 // Variables returns a list of variabless for the given environment


### PR DESCRIPTION
Creates kubernetes resources using `kubectl create`, may include
deployments, services, configmaps, and any other resources needed to
bootstrap a new environment.

![image](https://cloud.githubusercontent.com/assets/2295742/17230280/251724d8-54d0-11e6-962b-5740887b8e58.png)

