### PR TITLE
Allow slackbot to react to commands without an environment name

### DIFF
--- a/app/vili.go
+++ b/app/vili.go
@@ -30,7 +30,6 @@ const appName = "vili"
 // App is the wrapper for the tyr app
 type App struct {
 	server *server.Server
-	envs   *util.StringSet
 }
 
 // New returns a new server instance
@@ -240,7 +239,7 @@ func New() *App {
 // Start starts the app
 func (a *App) Start() {
 	go a.monitorEnvs()
-	go runDeployBot(a.envs)
+	go runDeployBot()
 	a.server.Start()
 }
 


### PR DESCRIPTION
When an env name isn't provided, iterate through the environments and
use the first one with the given branch name attached.
Also no longer spam errors to slack when an environment isn't found.