### PR TITLE
When loading an env template, fall back to main branch if ref not found

### DIFF
--- a/api/environments.go
+++ b/api/environments.go
@@ -52,10 +52,14 @@ func environmentTemplateHandler(c *echo.Context) error {
 
 	templ, err := templates.Environment(branch)
 	if err != nil {
-		return c.JSON(http.StatusOK, map[string]string{
-			"template": defaultTemplate,
-			"details":  err.Error(),
-		})
+		// Fall back to the main branch before returning a basic template
+		templ, err = templates.Environment("")
+		if err != nil {
+			return c.JSON(http.StatusOK, map[string]string{
+				"template": defaultTemplate,
+				"details":  err.Error(),
+			})
+		}
 	}
 	return c.JSON(http.StatusOK, map[string]string{
 		"template": string(templ),

--- a/templates/github.go
+++ b/templates/github.go
@@ -135,7 +135,11 @@ func (s *githubService) Pod(env, name string) (Template, error) {
 // Environment returns an environment template for the given branch
 func (s *githubService) Environment(branch string) (Template, error) {
 	path := s.resolvePath("", "environment.yaml")
-	fileContent, _, _, err := s.client.Repositories.GetContents(s.config.Owner, s.config.Repo, path, &github.RepositoryContentGetOptions{Ref: branch})
+	var opts *github.RepositoryContentGetOptions
+	if branch != "" {
+		opts = &github.RepositoryContentGetOptions{Ref: branch}
+	}
+	fileContent, _, _, err := s.client.Repositories.GetContents(s.config.Owner, s.config.Repo, path, opts)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This is typically the master branch, but can be configured on the git
server, so don't specify a ref at all if the preferred branch does not
exist.