### PR TITLE
Only refresh environments every 5 minutes instead of 15 seconds

### DIFF
--- a/app/vili.go
+++ b/app/vili.go
@@ -248,7 +248,7 @@ func (a *App) monitorEnvs() {
 		if err := environments.RefreshEnvs(); err != nil {
 			log.Warn("Unable to detect environments: ", err)
 		}
-		time.Sleep(15 * time.Second)
+		time.Sleep(5 * time.Minute)
 	}
 }
 


### PR DESCRIPTION
With instantly adding newly-created environments and hiding terminating
environments, we don't have a strong need to poll frequently, and this
will reduce the number of passive kubernetes and github api requests by
a factor of 20