### PR TITLE
Add "null" auth handler

### DIFF
--- a/app/vili.go
+++ b/app/vili.go
@@ -194,14 +194,21 @@ func New() *App {
 		// set up the auth service
 		func() {
 			defer wg.Done()
-			err := auth.InitOktaAuthService(&auth.OktaConfig{
-				Entrypoint: config.GetString(config.OktaEntrypoint),
-				Issuer:     config.GetString(config.OktaIssuer),
-				Cert:       config.GetString(config.OktaCert),
-				Domain:     config.GetString(config.OktaDomain),
-			})
-			if err != nil {
-				log.Panic(err)
+			switch config.GetString(config.AuthService) {
+			case "okta":
+				err := auth.InitOktaAuthService(&auth.OktaConfig{
+					Entrypoint: config.GetString(config.OktaEntrypoint),
+					Issuer:     config.GetString(config.OktaIssuer),
+					Cert:       config.GetString(config.OktaCert),
+					Domain:     config.GetString(config.OktaDomain),
+				})
+				if err != nil {
+					log.Fatal(err)
+				}
+			case "null":
+				auth.InitNullAuthService()
+			default:
+				log.Fatalf("Unknown auth service %s", config.GetString(config.AuthService))
 			}
 		},
 		// set up the slack service

--- a/auth/null.go
+++ b/auth/null.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/airware/vili/server"
+	"github.com/airware/vili/session"
+
+	"gopkg.in/labstack/echo.v1"
+)
+
+// Null implements a the auth Service interface and always auths
+type Null struct{}
+
+// InitNullAuthService sets the auth service to null
+func InitNullAuthService() error {
+	service = &Null{}
+	return nil
+}
+
+// AddHandlers implements the Service interface
+func (s *Null) AddHandlers(srv *server.Server) {
+	srv.Echo().Get("/login", s.loginHandler)
+}
+
+// Cleanup is a noop with the null handler
+func (s *Null) Cleanup() {
+	return
+}
+
+func (s *Null) loginHandler(c *echo.Context) error {
+	err := session.Login(c.Request(), c.Response(), &session.User{
+		Email:     "dev@dev.local",
+		Username:  "dev@dev.local",
+		FirstName: "nullauth",
+		LastName:  "nullauth",
+	})
+	if err != nil {
+		return err
+	}
+	return c.Redirect(http.StatusFound, "/")
+}

--- a/config/app.go
+++ b/config/app.go
@@ -20,6 +20,7 @@ const (
 	LogJSON                 = "log-json"
 	RedisPort               = "redis-port"
 	RedisDB                 = "redis-db"
+	AuthService             = "auth-service"
 	OktaEntrypoint          = "okta-entrypoint"
 	OktaIssuer              = "okta-issuer"
 	OktaCert                = "okta-cert"


### PR DESCRIPTION
This implementation of the auth.Service interface just logs you in
without any credential verification. Mainly for use in testing / local dev.

Happy to take feedback on the email/name etc. Figured it should be something obviously "wrong" for production deployments.

Fixes #55
