### PR TITLE
Add ability to scale deployments down to 0 replicas

### DIFF
--- a/api/apps.go
+++ b/api/apps.go
@@ -278,7 +278,7 @@ func appCreateServiceHandler(c *echo.Context) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
-// DeploymentScaleRequest is a request to
+// DeploymentScaleRequest is a request to scale a deployment
 type DeploymentScaleRequest struct {
 	Replicas *int `json:"replicas"`
 }

--- a/kube/extensions/v1beta1/types.go
+++ b/kube/extensions/v1beta1/types.go
@@ -29,7 +29,7 @@ import (
 // describes the attributes of a scale subresource
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
-	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
+	Replicas int32 `json:"replicas" protobuf:"varint,1,opt,name=replicas"`
 }
 
 // represents the current status of a scale subresource.


### PR DESCRIPTION
Fixes issue where a ScaleSpec with Replicas=0 would be ommitted in the
json representation, causing the scale operation to be a no-op.